### PR TITLE
feat: remappable prompt-suggest accept key via keybindings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ pi install npm:pi-xai
 | `/plan` | Plan mode (`on` / `off` / `status` / `show`); tools `enter_plan_mode` / `exit_plan_mode` |
 | `/imagine` | Image gen — prompt passed **verbatim** to `image_gen` |
 | `/imagine-video` | Video workflow (`image_gen` → `image_to_video`) |
-| `/xai-suggest` | Next-prompt ghost (`on` / `off` / `clear`); **Tab** commits |
+| `/xai-suggest` | Next-prompt ghost (`on` / `off` / `clear`); **Tab** commits (remap via `~/.pi/agent/keybindings.json`: `"ext.pi-xai.promptSuggest.accept": "ctrl+right"`, then `/reload`) |
 | `/xai-usage` | Monthly/weekly subscription bars (`% left`) + reset |
 | `/xai-usage statusbar` | Footer `Grok 40% left · 3d 12h` (Grok models only) |
 | `/xai-vision:status` | Vision routing for text-only models (Composer default) |

--- a/tests/xai-keybindings.test.ts
+++ b/tests/xai-keybindings.test.ts
@@ -1,0 +1,21 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { PROMPT_SUGGEST_ACCEPT_ID, resolveKeybindingKey } from "../xai-config.ts";
+
+describe("resolveKeybindingKey", () => {
+  it("reads string and first array entry; falls back", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pi-xai-kb-"));
+    const path = join(dir, "keybindings.json");
+
+    writeFileSync(path, JSON.stringify({ [PROMPT_SUGGEST_ACCEPT_ID]: "Ctrl+Right" }));
+    expect(resolveKeybindingKey(PROMPT_SUGGEST_ACCEPT_ID, "tab", path)).toBe("ctrl+right");
+
+    writeFileSync(path, JSON.stringify({ [PROMPT_SUGGEST_ACCEPT_ID]: ["alt+enter", "f6"] }));
+    expect(resolveKeybindingKey(PROMPT_SUGGEST_ACCEPT_ID, "tab", path)).toBe("alt+enter");
+
+    writeFileSync(path, "{}");
+    expect(resolveKeybindingKey(PROMPT_SUGGEST_ACCEPT_ID, "tab", path)).toBe("tab");
+  });
+});

--- a/xai-config.ts
+++ b/xai-config.ts
@@ -10,6 +10,10 @@ export const XAI_CLI_BASE = "https://cli-chat-proxy.grok.com/v1";
 
 export const USER_PI_SETTINGS_PATH = resolve(homedir(), ".pi/agent/settings.json");
 export const PROJECT_PI_SETTINGS_PATH = resolve(process.cwd(), ".pi/settings.json");
+export const USER_PI_KEYBINDINGS_PATH = resolve(homedir(), ".pi/agent/keybindings.json");
+
+/** Remap in ~/.pi/agent/keybindings.json (Pi core ignores ext.* ids; we read them ourselves). */
+export const PROMPT_SUGGEST_ACCEPT_ID = "ext.pi-xai.promptSuggest.accept";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -41,6 +45,23 @@ function getString(record: JsonRecord, key: string): string | undefined {
 
 export function getPiSettingsPaths(): { user: string; project: string } {
   return { user: USER_PI_SETTINGS_PATH, project: PROJECT_PI_SETTINGS_PATH };
+}
+
+/** First key bound to `id` in keybindings.json, else `fallback`. Pi does not remap ext.* yet. */
+export function resolveKeybindingKey(
+  id: string,
+  fallback: string,
+  path = USER_PI_KEYBINDINGS_PATH,
+): string {
+  const raw = readJsonRecord(path);
+  const v = raw[id];
+  if (typeof v === "string" && v.trim()) return v.trim().toLowerCase();
+  if (Array.isArray(v)) {
+    for (const item of v) {
+      if (typeof item === "string" && item.trim()) return item.trim().toLowerCase();
+    }
+  }
+  return fallback;
 }
 
 export interface ResolvedXaiConfig {

--- a/xai-prompt-suggest.ts
+++ b/xai-prompt-suggest.ts
@@ -10,7 +10,7 @@
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { getEffectiveXaiApiKey } from "./xai-oauth.ts";
-import { resolveXaiConfig } from "./xai-config.ts";
+import { PROMPT_SUGGEST_ACCEPT_ID, resolveKeybindingKey, resolveXaiConfig } from "./xai-config.ts";
 import { xaiRequestHeaders } from "./xai-stream.ts";
 
 const SUGGEST_SYSTEM =
@@ -299,14 +299,21 @@ export function registerXaiPromptSuggest(api: ExtensionAPI): void {
     },
   });
 
-  api.registerShortcut("tab", {
-    description: "Accept predicted next prompt in textbox",
-    handler: async (ctx) => {
-      lastUi = ctx.ui;
-      if (!isPromptSuggestEnabled() || !suggestion || !ghostInEditor) return;
-      acceptInTextbox();
-    },
-  });
+  // Pi core ignores ext.* in keybindings.json; we resolve the physical key ourselves.
+  // Sync false falls through so default key still does autocomplete when no ghost.
+  const acceptKey = resolveKeybindingKey(PROMPT_SUGGEST_ACCEPT_ID, "tab");
+  api.registerShortcut(
+    acceptKey as "tab",
+    {
+      id: PROMPT_SUGGEST_ACCEPT_ID,
+      description: "Accept predicted next prompt in textbox",
+      handler: (ctx) => {
+        lastUi = ctx.ui;
+        if (!isPromptSuggestEnabled() || !suggestion || !ghostInEditor) return false;
+        acceptInTextbox();
+      },
+    } as { description?: string; handler: (ctx: ExtensionContext) => void | Promise<void> },
+  );
 
   // Submit: strip dim ANSI so the model never sees escape codes.
   api.on("input", async (event) => {


### PR DESCRIPTION
## Summary

Pi core currently ignores unknown `ext.*` action ids in `~/.pi/agent/keybindings.json` (only built-in definitions are applied). As a result, documenting `ext.pi-xai.promptSuggest.accept` alone never remapped the hard-coded `tab` shortcut for accepting the next-prompt ghost.

This change makes **pi-xai** read that keybinding itself and register the resolved physical key at startup (default remains `tab`).

## Changes

- Add `resolveKeybindingKey()` + `PROMPT_SUGGEST_ACCEPT_ID` in `xai-config.ts`
- Register `registerShortcut(resolvedKey, …)` in `xai-prompt-suggest.ts` instead of always `"tab"`
- Document remap + `/reload` in README
- Unit test for string / array / fallback resolution

## Usage

```json
// ~/.pi/agent/keybindings.json
{
  "ext.pi-xai.promptSuggest.accept": "ctrl+right"
}
```

Then run `/reload` (or restart Pi) so the extension re-reads keybindings.

## Why not wait for Pi core?

Upstream keybinding rebuild skips ids not present in the built-in `KEYBINDINGS` map, and extension shortcuts are keyed by the physical key passed to `registerShortcut`, not by a remappable action id. Reading the file in the package is the smallest path that works today; when Pi gains first-class extension keybinding ids, this can shrink to a pure id registration.

## Test plan

- [x] `npx vitest run tests/xai-keybindings.test.ts`
- [ ] With default config: ghost still accepts on **Tab** when present
- [ ] With `"ext.pi-xai.promptSuggest.accept": "ctrl+right"` + `/reload`: **Ctrl+Right** accepts ghost; Tab no longer does
- [ ] Missing / invalid keybindings file: falls back to `tab`