### PR TITLE
feat: add Grok 4.6 to grok-build catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Grok 4.6** (`grok-4.6`) in the `grok-build` model picker — 500k context, vision, reasoning + `xhigh` effort, encrypted reasoning include. Default for `xai_generate_text` and the vision describer.
+
 ## [0.17.1] - 2026-07-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pi install npm:pi-xai
 
 ```text
 /login grok-build
-/model grok-build/grok-4.5
+/model grok-build/grok-4.6
 ```
 
 | Command | What it does |
@@ -131,7 +131,8 @@ Public API override:
 | --- | ---: | --- | --- |
 | `grok-composer-2.5-fast` | 200K | text | Fast coding; vision routing on by default |
 | `grok-build` | 500K | text + image | Coding |
-| `grok-4.5` | 500K | text + image | Flagship reasoning |
+| `grok-4.6` | 500K | text + image | Flagship reasoning |
+| `grok-4.5` | 500K | text + image | Previous flagship |
 | `grok-4.3` | 1M | text + image | Long context |
 | `grok-4.20-0309-reasoning` | 2M | text + image | Auto reasoning |
 | `grok-4.20-0309-non-reasoning` | 2M | text + image | Fast 4.20 |
@@ -231,7 +232,7 @@ Needs Grok Build OAuth. Web: [grok.com usage](https://grok.com/?_s=usage).
 
 ### Vision routing (Composer)
 
-Default **`composer`**: images from `read` → describe via `grok-4.5` → text.
+Default **`composer`**: images from `read` → describe via `grok-4.6` → text.
 
 ```text
 /xai-vision:composer | on | off | status | cache-clear

--- a/index.ts
+++ b/index.ts
@@ -592,14 +592,22 @@ export default async function (api: ExtensionAPI) {
         prompt: Type.String({ description: "User prompt / message" }),
         model: Type.Optional(
           Type.String({
-            description: "Model override (default: grok-4.5)",
+            description: "Model override (default: grok-4.6)",
           }),
         ),
         reasoningEffort: Type.Optional(
-          Type.Union([Type.Literal("low"), Type.Literal("medium"), Type.Literal("high")], {
-            description:
-              "grok-4.5 / grok-4.3: low/medium/high (API default high; cannot disable). Prefer low for latency-sensitive agentic use.",
-          }),
+          Type.Union(
+            [
+              Type.Literal("low"),
+              Type.Literal("medium"),
+              Type.Literal("high"),
+              Type.Literal("xhigh"),
+            ],
+            {
+              description:
+                "grok-4.6: low/medium/high/xhigh. grok-4.5 / grok-4.3: low/medium/high (API default high; cannot disable). Prefer low for latency-sensitive agentic use.",
+            },
+          ),
         ),
         system: Type.Optional(Type.String({ description: "System/developer instruction" })),
         previousResponseId: Type.Optional(
@@ -671,7 +679,7 @@ export default async function (api: ExtensionAPI) {
           }
         }
 
-        const modelToUse = model || "grok-4.5";
+        const modelToUse = model || "grok-4.6";
         const isReasoningModel =
           grokSupportsReasoningEffort(modelToUse) ||
           modelToUse === "grok-build" ||

--- a/tests/xai-protocol.test.ts
+++ b/tests/xai-protocol.test.ts
@@ -107,8 +107,10 @@ describe("Responses payload helpers", () => {
   });
 
   test("reasoning model gates", () => {
+    expect(grokSupportsReasoningEffort("grok-4.6")).toBe(true);
     expect(grokSupportsReasoningEffort("grok-4.5")).toBe(true);
     expect(grokSupportsReasoningEffort("grok-build")).toBe(false);
+    expect(grokWantsEncryptedReasoningInclude("grok-4.6")).toBe(true);
     expect(grokWantsEncryptedReasoningInclude("grok-4.5")).toBe(true);
     expect(grokWantsEncryptedReasoningInclude("grok-build")).toBe(false);
     expect(grokWantsEncryptedReasoningInclude("grok-4.20-reasoning")).toBe(true);
@@ -130,6 +132,8 @@ describe("Responses payload helpers", () => {
 describe("model catalog", () => {
   test("ids + context windows from official/live catalog knowledge", () => {
     const byId = Object.fromEntries(GROK_BUILD_MODELS.map((m) => [m.id, m]));
+    expect(byId["grok-4.6"]?.contextWindow).toBe(500_000);
+    expect(byId["grok-4.6"]?.thinkingLevelMap?.xhigh).toBe("xhigh");
     expect(byId["grok-4.5"]?.contextWindow).toBe(500_000);
     expect(byId["grok-build"]?.contextWindow).toBe(500_000);
     expect(byId["grok-composer-2.5-fast"]?.contextWindow).toBe(200_000);

--- a/tests/xai-vision.test.ts
+++ b/tests/xai-vision.test.ts
@@ -126,6 +126,7 @@ describe("normalizeConfig / loadConfig", () => {
   });
 
   it("describable models are vision-capable (exclude composer)", () => {
+    expect(describableModels()).toContain("grok-4.6");
     expect(describableModels()).toContain("grok-4.5");
     expect(describableModels()).toContain("grok-4.3");
     expect(describableModels()).not.toContain("grok-composer-2.5-fast");
@@ -166,7 +167,7 @@ describe("composer model input", () => {
   });
 
   it("keeps native vision on flagship models", () => {
-    for (const id of ["grok-4.5", "grok-4.3"]) {
+    for (const id of ["grok-4.6", "grok-4.5", "grok-4.3"]) {
       const m = GROK_BUILD_MODELS.find((x) => x.id === id);
       expect(m?.input).toContain("image");
     }
@@ -244,7 +245,7 @@ describe("handleReadResult — no-op cases", () => {
 });
 
 describe("handleReadResult — image routing", () => {
-  it("describes an image via grok-4.5 and replaces it with text", async () => {
+  it("describes an image via grok-4.6 and replaces it with text", async () => {
     const ctx = buildCtx();
     const result = await handleReadResult(readEvent([imageBlock()]), ctx);
 

--- a/xai-config.ts
+++ b/xai-config.ts
@@ -71,6 +71,7 @@ export function resolveXaiConfig(): ResolvedXaiConfig {
 const GROK_EFFORT_PREFIXES = [
   "grok-3-mini",
   "grok-4.20-multi-agent",
+  "grok-4.6",
   "grok-4.5",
   "grok-4.3",
 ] as const;

--- a/xai-provider.ts
+++ b/xai-provider.ts
@@ -9,6 +9,7 @@ const COST_BUILD = { input: 1, output: 2, cacheRead: 0.2, cacheWrite: 0.2 };
 const COST_COMPOSER_FAST = { input: 3, output: 15, cacheRead: 0.5, cacheWrite: 0 };
 const COST_43 = { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 };
 const COST_45 = { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 };
+const COST_46 = { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 };
 const COST_420 = { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 };
 
 export interface GrokBuildModelSpec {
@@ -51,6 +52,23 @@ const GROK_BUILD_MODEL_SPECS: GrokBuildModelSpec[] = [
     maxTokens: 30_000,
     input: ["text", "image"],
     cost: COST_BUILD,
+  },
+  {
+    id: "grok-4.6",
+    name: "Grok 4.6",
+    reasoning: true,
+    contextWindow: 500_000,
+    maxTokens: 131_072,
+    input: ["text", "image"],
+    cost: COST_46,
+    thinkingLevelMap: {
+      off: null,
+      minimal: "low",
+      low: "low",
+      medium: "medium",
+      high: "high",
+      xhigh: "xhigh",
+    },
   },
   {
     id: "grok-4.5",

--- a/xai-vision.ts
+++ b/xai-vision.ts
@@ -35,7 +35,7 @@ export const getConfigPath = () => join(homePath(), ".pi", "xai-vision.json");
 export const getCachePath = () => join(homePath(), ".pi", "xai-vision-cache.json");
 
 /** Vision-capable flagship; not composer (text-only) and not legacy grok-build. */
-export const DEFAULT_DESCRIBE_MODEL = "grok-4.5";
+export const DEFAULT_DESCRIBE_MODEL = "grok-4.6";
 export const DEFAULT_MAX_IMAGES = 4;
 export const DEFAULT_CACHE_MAX_ENTRIES = 100;
 


### PR DESCRIPTION
Register grok-4.6 as the flagship (500k, vision, xhigh effort). Point xai_generate_text and the vision describer at it; keep 4.5 listed.